### PR TITLE
refactor: 로그인 테스트를 개선한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**
+**/src/test/resources/local.properties
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # occupying
+
+## for testing
+### `local.properties` 파일 생성
+테스트를 위해서 `**/src/test/resources/`에 `local.properties` 파일을 생성합니다.
+```
+   id={코레일계정}
+   pw={코레일비밀번호}
+```

--- a/src/test/kotlin/com/kh/occupying/KorailTest.kt
+++ b/src/test/kotlin/com/kh/occupying/KorailTest.kt
@@ -1,16 +1,27 @@
 package com.kh.occupying
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.springframework.core.io.ClassPathResource
+import java.util.*
 
 class KorailTest {
 
+    lateinit var id: String
+    lateinit var pw: String
+
+    @Before
+    fun setUp() {
+        val resource = ClassPathResource("local.properties")
+        val prop = Properties()
+        prop.load(resource.inputStream)
+        id = prop.getProperty("id")
+        pw = prop.getProperty("pw")
+    }
+
     @Test
     fun `given id and password login method will return result correctly`() {
-        // Arrange
-        val id = "korail-id"
-        val pw = "korail-pw"
-
         // Act
         val actual = Korail().login(id, pw)
 
@@ -21,5 +32,6 @@ class KorailTest {
         assertThat(actual.email).isNotEmpty()
         assertThat(actual.userName).isNotEmpty()
     }
+
 }
 


### PR DESCRIPTION
로그인 테스트 시 사용되는 계정정보를
GIT에 공개할 수 없으므로 임시 데이터로 커밋을 해놓았었다

classPath:test/resources/local.properties 경로에 계정정보를
입력해놓고 gitignore 설정을 해서 작업에 불편함이 없도록 개선한다